### PR TITLE
(#36) Export Export-CCMDeploymentReport command

### DIFF
--- a/src/ChocoCCM.psd1
+++ b/src/ChocoCCM.psd1
@@ -12,7 +12,7 @@
 RootModule = 'ChocoCCM.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.1.1'
+ModuleVersion = '0.1.2'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -88,10 +88,10 @@ FunctionsToExport = @('Connect-CCMServer',
 'Start-CCMDeployment',
 'Stop-CCMDeployment',
 'Export-CCMDeployment',
+'Export-CCMDeploymentReport',
 'Move-CCMDeploymentToReady',
 'Disable-CCMDeployment',
 'Get-DeploymentResult',
-'Export-CCMDeploymentDetail',
 'Get-CCMOutdatedSoftwareMember',
 'Get-CCMOutdatedSoftware',
 'New-CCMOutdatedSoftwareReport',
@@ -150,4 +150,3 @@ PrivateData = @{
 # DefaultCommandPrefix = ''
 
 }
-


### PR DESCRIPTION
This PR ensures that the command necessary to export deployment reports is available when the module is imported.

- Removed the unused Export-CCMDeploymentDetail
- Added the missing Export-CCMDeploymentReport

Fixes #36