### PR TITLE
Change Example & Set -Group Param to not be mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ This will setup and store a $Session variable
 1. Clone this repository:
 
     ```powershell
-    git clone https://gitlab.com/chocolatey/central-management/chocoCCM.git
+    git clone https://github.com/chocolatey/ChocoCCM.git
+    cd ChocoCCM
     ```
 
 2. Run build script

--- a/src/Public/Add-CCMGroupMember.ps1
+++ b/src/Public/Add-CCMGroupMember.ps1
@@ -111,18 +111,8 @@ function Add-CCMGroupMember {
             Name        = $current.Name
             Id          = $current.Id
             Description = $current.Description
-            Groups      = if ($GroupCollection.Count -gt 0) {
-                $GroupCollection.ToArray()
-            }
-            else {
-                $null
-            }
-            Computers   = if ($ComputerCollection.Count -gt 0) {
-                $ComputerCollection.ToArray()
-            }
-            else {
-                $null
-            }
+            Groups      = $GroupCollection
+            Computers   = $ComputerCollection
         } | ConvertTo-Json -Depth 3
 
         Write-Verbose $body

--- a/src/Public/Add-CCMGroupMember.ps1
+++ b/src/Public/Add-CCMGroupMember.ps1
@@ -16,14 +16,19 @@ function Add-CCMGroupMember {
     The group(s) to add
 
     .EXAMPLE
-    Add-CCMGroupMember -Group 'Newly Imaged' -Computer Lab1,Lab2,Lab3
+    Add-CCMGroupMember -Name 'Newly Imaged' -Computer Lab1,Lab2,Lab3
+
+    .EXAMPLE
+    Add-CCMGroupMember -Name 'Newly Imaged' -Group 'New Laptops' -Computer Lab1,Lab2,Lab3
+
+    .EXAMPLE
+    Add-CCMGroupMember -Name 'Newly Imaged' -Group 'New Laptops'
 
     #>
-    [CmdletBinding(HelpUri = "https://docs.chocolatey.org/en-us/central-management/chococcm/functions/addccmgroupmember")]
+    [CmdletBinding(HelpUri = "https://docs.chocolatey.org/en-us/central-management/chococcm/functions/addccmgroupmember", DefaultParameterSetName = 'Computer')]
     param(
-        [Parameter(Mandatory)]
-        [Parameter(ParameterSetName = "Computer")]
-        [Parameter(ParameterSetName = "Group")]
+        [Parameter(Mandatory, ParameterSetName = "Computer")]
+        [Parameter(Mandatory, ParameterSetName = "Group")]
         [ArgumentCompleter(
             {
                 param($Command, $Parameter, $WordToComplete, $CommandAst, $FakeBoundParams)
@@ -106,8 +111,18 @@ function Add-CCMGroupMember {
             Name        = $current.Name
             Id          = $current.Id
             Description = $current.Description
-            Groups      = @($GroupCollection)
-            Computers   = @($ComputerCollection)
+            Groups      = if ($GroupCollection.Count -gt 0) {
+                $GroupCollection.ToArray()
+            }
+            else {
+                $null
+            }
+            Computers   = if ($ComputerCollection.Count -gt 0) {
+                $ComputerCollection.ToArray()
+            }
+            else {
+                $null
+            }
         } | ConvertTo-Json -Depth 3
 
         Write-Verbose $body


### PR DESCRIPTION
## Description Of Changes

Changed example to only use mandatory parameters. Also changed -Group parameter to no longer be mandatory as originally intended. 

## Motivation and Context
If group is mandatory this command does not work as expected.

## Testing
@corbob is testing this

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [X] Breaking change (fix or feature that could cause existing functionality to change)
* [X] PowerShell code changes.

## Related Issue

Fixes #50 

## Change Checklist

* [X] Requires a change to the documentation
* [X] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
