### PR TITLE
Update to Add-CCMGroupMember - fixes groups vs computers

### DIFF
--- a/.github/ISSUE_TEMPLATE/enhancement--feature-request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement--feature-request.md
@@ -1,0 +1,12 @@
+---
+name: Enhancement/ Feature request
+about: Suggest an idea for this project
+title: "[FEATURE]"
+labels: ''
+assignees: ''
+
+---
+
+<!--
+
+This is a blank slate! Have fun, please abide by our [Etiquette](https://github.com/chocolatey/choco/blob/master/README.md#etiquette-regarding-communication) when communicating on this repository.

--- a/.github/ISSUE_TEMPLATE/report-an-issue.md
+++ b/.github/ISSUE_TEMPLATE/report-an-issue.md
@@ -1,0 +1,42 @@
+---
+name: Report An Issue
+about: Having trouble? Use this to report an issue!
+title: "[BUG]"
+labels: ''
+assignees: ''
+
+---
+
+<!--
+Please check to see if your issue already exists with a quick search of the issues. Start with one relevant term and then add if you get too many results.
+
+NOTE: Keep in mind we have an etiquette regarding communication that we expect folks to observe when they are looking for support in the Chocolatey community. https://github.com/chocolatey/choco/blob/master/README.md#etiquette-regarding-communication
+-->
+
+### What You Are Seeing?
+
+### What is Expected?
+
+### How Did You Get This To Happen? (Steps to Reproduce)
+
+### Output Log
+<!--
+When including the log information, please ensure you have run the command -Verbose. It provides important information for determining an issue
+
+- Make sure there is no sensitive data shared.
+- We need ALL output, not just what you may believe is relevant.
+-->
+
+
+<details>
+<summary>Full Log Output</summary>
+
+<p>
+
+~~~sh
+PLACE FULL COMMAND OUTPUT HERE
+~~~
+
+</p>
+
+</details>

--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 This module servers to be a PowerShell wrapper to the underlying API that drives pretty much every aspect of Chocolatey Central Management
 
+## Contributing
+
+Happy to accept new features and fixes. Outstanding issues which can be worked on tagged `Up For Grabs` under issues.
+
+### Submitting a PR
+
+Here's the general process of fixing an issue in the DSC Resource Kit:
+1. Fork the repository.
+3. Clone your fork to your machine.
+4. It's preferred to create a non-master working branch where you store updates.
+5. Make changes.
+6. Write pester tests to ensure that the issue is fixed.
+7. Submit a pull request to the development branch.
+9. Make sure your code does not contain merge conflicts.
+10. Address comments (if any).
+
 ## Installation
 
 1. Clone this repository:

--- a/src/Public/Add-CCMGroupMember.ps1
+++ b/src/Public/Add-CCMGroupMember.ps1
@@ -1,4 +1,4 @@
-function Add-CCMGroupMember2 {
+function Add-CCMGroupMember {
     <#
     .SYNOPSIS
     Adds a member to an existing Group in Central Management

--- a/src/Public/Add-CCMGroupMember.ps1
+++ b/src/Public/Add-CCMGroupMember.ps1
@@ -1,29 +1,29 @@
-function Add-CCMGroupMember {
+function Add-CCMGroupMember2 {
     <#
     .SYNOPSIS
     Adds a member to an existing Group in Central Management
     
     .DESCRIPTION
-    Add new computers and groups to existing Central Management Groups
-    
-    .PARAMETER Name
+    Add new computers and | or groups to existing Central Management Groups. At least one must be used.
+        
+    .PARAMETER Name [MANDATORY]
     The group to edit
     
-    .PARAMETER Computer
+    .PARAMETER Computer [OPTIONAL]
     The computer(s) to add
     
-    .PARAMETER Group
+    .PARAMETER Group [OPTIONAL]
     The group(s) to add
     
     .EXAMPLE
-    Add-CCMGroupMember -Group 'Newly Imaged' -Computer Lab1,Lab2,Lab3
+    Add-CCMGroupMember -Name 'All Newly Imaged' -Group 'New Laptops' -Computer Lab1,Lab2,Lab3
+    Add-CCMGroupMember -Name 'All Newly Imaged' -Computer Lab1,Lab2,Lab3
+    Add-CCMGroupMember -Name 'All Newly Imaged' -Group 'New Laptops'
     
     #>
     [cmdletBinding(HelpUri = "https://chocolatey.org/docs/add-ccmgroup-member")]
     param(
         [parameter(Mandatory = $true)]
-        [parameter(ParameterSetName = "Computer")]
-        [parameter(ParameterSetName = "Group")]
         [ArgumentCompleter(
             {
                 param($Command, $Parameter, $WordToComplete, $CommandAst, $FakeBoundParams)
@@ -42,15 +42,10 @@ function Add-CCMGroupMember {
         )]
         [string]
         $Name,
-        
-        [parameter(Mandatory = $true, ParameterSetName = "Computer")]
-        [Parameter(ParameterSetName='Group')]
-        [string[]]
-        $Computer,
+         
+        [string]$Computer,
 
-        [parameter(Mandatory = $true ,ParameterSetName = "Group")]
-        [string[]]
-        $Group
+        [string]$Group
     )
 
     begin {
@@ -58,6 +53,8 @@ function Add-CCMGroupMember {
         if (-not $Session) {
             throw "Not authenticated! Please run Connect-CCMServer first!"
         }
+
+        if(-not($Computer) -and (-not($Group))) { Throw “Please ensure that at least one parameter is used to add member(s): Computer | Group” }
         
         $computers = Get-CCMComputer
         $groups = Get-CCMGroup
@@ -67,15 +64,16 @@ function Add-CCMGroupMember {
 
         $id = Get-CCMGroup -Group $name | Select-Object -ExpandProperty Id
         $current = Get-CCMGroup -Id $id | Select-Object *
-        $current.computers | ForEach-Object { $ComputerCollection.Add([pscustomobject]@{computerId = "$($_.computerId)" }) }
-        
     }
+   
 
-    process {
-
-        switch ($PSCmdlet.ParameterSetName) {
-            { $Computer } {
-
+    process{
+        if ([string]::IsNullOrEmpty($Computer)){
+                $processedComputers = @()
+        }
+       
+        else {
+            
                 foreach ($c in $Computer) {
                     if($c -in $current.computers.computerName){
                         Write-Warning "Skipping $c, already exists"
@@ -85,35 +83,46 @@ function Add-CCMGroupMember {
                         $ComputerCollection.Add([pscustomobject]@{computerId = "$($Cresult.Id)" })
                     }
                 }
-
-                $processedComputers = $ComputerCollection
-                
             }
+         
+        #Add any current computers into the array
+        $current.computers | ForEach-Object { $ComputerCollection.Add([pscustomobject]@{computerId = "$($_.computerId)" }) }             
+        $processedComputers = $ComputerCollection           
+            
 
-            'Group' {
-
+       if ([string]::IsNullOrEmpty($Group)) {
+                $processedGroups = @()
+       }
+       else {
+        
                 foreach ($g in $Group) {
                     if($g -in $current.groups.subGroupName){
                         Write-Warning "Skipping $g, already exists"
                     }
                     else {
-                    $Gresult = $groups | Where-Object { $_.Name -eq "$g" } | Select-Object Id
-                    $GroupCollection.Add([pscustomobject]@{subGroupId = "$($Gresult.Id)"})
+                        $Gresult = $groups | Where-Object { $_.Name -eq "$g" } | Select-Object Id
+                        $GroupCollection.Add([pscustomobject]@{subGroupId = "$($Gresult.Id)"})
+                    }
                 }
-                }
-                $processedGroups = $GroupCollection
             }
-        }
+          
+       
+        #Add any current groups into the array
+        $current.groups | ForEach-Object { $GroupCollection.Add([pscustomobject]@{subGroupId = "$($_.subGroupId)" }) }             
+        $processedGroups = $GroupCollection           
+            
         
         $body = @{
             Name        = $Name
             Id          = ($groups | Where-Object { $_.name -eq "$Name" } | Select-Object  -ExpandProperty Id)
             Description = ($groups | Where-Object { $_.name -eq "$Name" } | Select-Object  -ExpandProperty Description)
-            Groups      = if (-not $processedGroups) { @() } else { @(,$processedGroups) }
-            Computers   = if (-not $processedComputers) { @() } else { @(,$processedComputers) }
+            Groups      = $processedGroups
+            Computers   = $processedComputers
+
         } | ConvertTo-Json -Depth 3
 
         Write-Verbose $body
+        write-host $body
         $irmParams = @{
             Uri         = "$($protocol)://$hostname/api/services/app/Groups/CreateOrEdit"
             Method      = "post"
@@ -135,7 +144,7 @@ function Add-CCMGroupMember {
 
         }
 
-        catch {
+         catch {
             throw $_.Exception.Message
         }
     }


### PR DESCRIPTION
Updated so that the add-ccmgroupmember works properly
- Changed computer and group to not be mandatory
- Added throw to require either/or computer and group to be set
- Set processedGroups and processedComputers to arrays prior to fill to prevent incorrect JSON datatype being passes to API