### PR TITLE
(#74) Use PreReleaseTag for versioning

### DIFF
--- a/ChocoCCM.build.ps1
+++ b/ChocoCCM.build.ps1
@@ -177,7 +177,7 @@ task Build Clean, InstallGitVersion, ScriptAnalyzer, {
         ModuleVersion = $versionInfo.MajorMinorPatch
     }
 
-    $prerelease = $versionInfo.PreReleaseLabel -replace '-'
+    $prerelease = $versionInfo.NuGetPreReleaseTagV2 -replace '[^a-z0-9]'
     if ($prerelease) {
         if ($prerelease -notmatch '^(alpha|beta)') {
             $prerelease = "alpha$prerelease"


### PR DESCRIPTION
## Description Of Changes

- When doing versioning, use the PreReleaseTag, which contains an auto-incremented value based on commits, to ensure that the version number should be unique for each build.

## Motivation and Context

So we can maintain versioned prerelease versions internally for testing purposes.

## Testing

1. Checked the gitversion output to check for which properties we should be making use of
2. Running the PR build on our build server to see how it goes

## Change Types Made

* [x] Build issue fix
* [ ] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Fixes #74

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
