### PR TITLE
(#76) Cleanup and fix weird dev module behaviour

### DIFF
--- a/ChocoCCM.build.ps1
+++ b/ChocoCCM.build.ps1
@@ -160,7 +160,7 @@ task Build Clean, InstallGitVersion, ScriptAnalyzer, {
     $manifest = Copy-Item "$script:SourceFolder/ChocoCCM.psd1" -Destination "$OutputDirectory/ChocoCCM" -PassThru
 
     $moduleScripts = @(
-        Get-Item "$script:SourceFolder/module.psm1"
+        Get-Item "$script:SourceFolder/module.ps1"
         Get-Item "$script:SourceFolder/Private/*.ps1"
         Get-Item "$script:SourceFolder/Public/*.ps1"
     )

--- a/src/ChocoCCM.psm1
+++ b/src/ChocoCCM.psm1
@@ -3,7 +3,7 @@
 # the `module.psm1` script.
 
 $filesToImport = Get-Item @(
-    "$PSScriptRoot\module.psm1"
+    "$PSScriptRoot\module.ps1"
     "$PSScriptRoot\Public\*.ps1"
     "$PSScriptRoot\Private\*.ps1"
 )

--- a/src/Public/Add-CCMGroup.ps1
+++ b/src/Public/Add-CCMGroup.ps1
@@ -70,7 +70,7 @@ function Add-CCMGroup {
             else {
                 $Gresult = $groups | Where-Object Name -EQ $item | Select-Object -ExpandProperty Id
                 # Drop object into $computerCollection
-                [pscustomobject]@{subGroupId = $Gresult }
+                [pscustomobject]@{ subGroupId = $Gresult }
             }
         }
 


### PR DESCRIPTION
## Description Of Changes

- Renamed module.psm1 to module.ps1
- Changed the dot-sourcing in the dev-time ChocoCCM.psm1 to load it from the new name

## Motivation and Context

Previously importing the module from src/ChocoCCM.psd1 or src/ChocoCCM.psm1 would open a notepad window. This seems to be because dot-sourcing PSM1 files is not permitted and it simply invokes the file. Instead, just rename the module.psm1 to module.ps1 so it can be dot- sourced.

## Testing

1. Import the dev-time module with `Import-Module ./src/ChocoCCM.psd1`
2. No Notepad window should be created

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

Fixes #76

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
