### PR TITLE
(#59) Fix BadRequest errors for group commands

### DIFF
--- a/src/Public/Add-CCMGroup.ps1
+++ b/src/Public/Add-CCMGroup.ps1
@@ -82,18 +82,8 @@ function Add-CCMGroup {
         $body = @{
             Name        = $Name
             Description = $Description
-            Groups      = if (-not $processedGroups) {
-                @()
-            }
-            else {
-                @(, $processedGroups)
-            }
-            Computers   = if (-not $processedComputers) {
-                @()
-            }
-            else {
-                @(, $processedComputers)
-            }
+            Groups      = @($processedGroups)
+            Computers   = @($processedComputers)
         } | ConvertTo-Json
 
         $irmParams = @{

--- a/src/Public/Get-CCMGroupMember.ps1
+++ b/src/Public/Get-CCMGroupMember.ps1
@@ -41,37 +41,15 @@ function Get-CCMGroupMember {
 
     process {
         $Id = (Get-CCMGroup -Group $Group).Id
-        $irmParams = @{
-            Uri         = "$($protocol)://$hostname/api/services/app/Groups/GetGroupForEdit?id=$Id"
-            Method      = "GET"
-            ContentType = "application/json"
-            WebSession  = $Session
-        }
-
-        try {
-            $record = Invoke-RestMethod @irmParams -ErrorAction Stop
-        }
-        catch {
-            throw $_.Exception.Message
-        }
-
-        $cCollection = [System.Collections.Generic.List[psobject]]::new()
-        $gCollection = [System.Collections.Generic.List[psobject]]::new()
-
-        $record.result.computers | ForEach-Object {
-            $cCollection.Add($_)
-        }
-
-        $record.result.groups | ForEach-Object {
-            $gCollection.Add($_)
-        }
+        $result = Get-CCMGroup -Id $Id
 
         [pscustomobject]@{
-            Name        = $record.result.Name
-            Description = $record.result.Description
-            Groups      = @($gCollection)
-            Computers   = @($cCollection)
-            CanDeploy   = $record.result.isEligibleForDeployments
+            Id          = $result.Id
+            Name        = $result.Name
+            Description = $result.Description
+            Groups      = @($result.Groups | Where-Object { $_ })
+            Computers   = @($result.Computers | Where-Object { $_ })
+            CanDeploy   = $result.isEligibleForDeployments
         }
     }
 }

--- a/src/Public/Remove-CCMGroupMember.ps1
+++ b/src/Public/Remove-CCMGroupMember.ps1
@@ -57,15 +57,27 @@ function Remove-CCMGroupMember {
 
     process {
         $currentMembers = Get-CCMGroupMember -Group $Group
-        $G = Get-CCMGroup -Group $Group
-        $currentMembers | Add-Member -MemberType NoteProperty -Name Id -Value $G.Id
+        $computers = Get-CCMComputer
+        $groups = Get-CCMGroup
 
         foreach ($c in $ComputerMember) {
-            $currentMembers.Computers = @($($currentMembers.Computers | Where-Object { $_.ComputerName -ne $c }))
+            $cId = $computers | Where-Object { $_.Name -eq $c } | Select-Object -ExpandProperty Id
+            if (-not $cId) {
+                Write-Warning "No computer with the name $c was found, cannot remove it from the group"
+                continue
+            }
+
+            $currentMembers.Computers = @($currentMembers.Computers | Where-Object { $_.computerId -ne $cId })
         }
 
         foreach ($g in $GroupMember) {
-            $currentMembers.Groups = @($($currentMembers.Groups | Where-Object { $_.subGroupName -ne $g }))
+            $gId = $groups | Where-Object { $_.Name -eq $g } | Select-Object -ExpandProperty Id
+            if (-not $gId) {
+                Write-Warning "No group with the name $g was found, cannot remove it from the group"
+                continue
+            }
+
+            $currentMembers.Groups = @($currentMembers.Groups | Where-Object { $_.subGroupId -ne $g })
         }
 
         if (-not $currentMembers.Groups) {

--- a/src/Public/Set-CCMGroup.ps1
+++ b/src/Public/Set-CCMGroup.ps1
@@ -57,7 +57,7 @@ function Set-CCMGroup {
             throw "Not authenticated! Please run Connect-CCMServer first!"
         }
 
-        $existing = Get-CCMGroup -Group $Group
+        $existing = Get-CCMGroupMember -Group $Group
     }
 
     process {
@@ -80,11 +80,11 @@ function Set-CCMGroup {
             Method      = "POST"
             ContentType = "application/json"
             Body        = @{
-                Id          = $($existing.id)
+                Id          = $existing.id
                 Name        = $Name
                 Description = $Description
-                Groups      = @()
-                Computers   = @()
+                Groups      = $existing.Groups
+                Computers   = $existing.Computers
             } | ConvertTo-Json
             WebSession  = $Session
         }


### PR DESCRIPTION
## Description Of Changes
- Fixed BadRequest errors for Add-CcmGroup and Add-CcmGroupMember when working with groups that do not have any computers and/or subgroups.
- Updated Add/Remove-CcmGroupMember to continue to work with the changes to the other group commands
- Also updated Set-CcmGroup because it had issues with the changes to the above commands and was misbehaving.

## Motivation and Context

These commands should work with groups regardless of their memberships or not, and we should always be sending properly-formed API requests from this module as much as possible.

## Testing

1. Use `Add-CcmGroup` to add a new group with no members
2. Use `Add-CcmGroupMember` to add a computer to the group
3. Use `Remove-CcmGroupMember` to remove that computer from the group
4. Repeat the above two steps to add and remove another _group_ from the target group
5. Repeat steps 2 and 3 while adding/removing _both_ a computer and a group to the target group at once
6. Add a computer and a group back to the target group so it has some members
7. Use `Set-CcmGroup` to change the target group's name and/or description
8. Check the output from `Get-CcmGroupMember` to ensure that the group memberships are not removed.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Fixes #59

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.